### PR TITLE
DFC-2754 spell check takes the page down when circuit broken

### DIFF
--- a/DFC.Digital/DFC.Digital.Core/DFC.Digital.Core.csproj
+++ b/DFC.Digital/DFC.Digital.Core/DFC.Digital.Core.csproj
@@ -28,6 +28,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisIgnoreGeneratedCode>true</CodeAnalysisIgnoreGeneratedCode>
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -37,6 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>

--- a/DFC.Digital/DFC.Digital.Core/Interceptors/InstrumentationInterceptor.cs
+++ b/DFC.Digital/DFC.Digital.Core/Interceptors/InstrumentationInterceptor.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace DFC.Digital.Core.Interceptors
@@ -10,6 +11,7 @@ namespace DFC.Digital.Core.Interceptors
     {
         public const string Name = "Instrumentation";
 
+        private static readonly MethodInfo HandleAsyncMethodInfo = typeof(InstrumentationInterceptor).GetMethod("HandleAsyncWithResult", BindingFlags.Instance | BindingFlags.NonPublic);
         private IApplicationLogger loggingService;
 
         public InstrumentationInterceptor(IApplicationLogger logService)
@@ -24,12 +26,22 @@ namespace DFC.Digital.Core.Interceptors
                 throw new System.ArgumentNullException(nameof(invocation));
             }
 
+            if (loggingService.IsTraceDisabled())
+            {
+                invocation.Proceed();
+            }
+            else
+            {
+                HandleInterception(invocation);
+            }
+        }
+
+        private void HandleInterception(IInvocation invocation)
+        {
             var returnType = invocation.Method.ReturnType;
             if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(Task<>))
             {
-                bool shouldIgnoreInput = invocation.Method.CustomAttributes.Any(a => a.AttributeType == typeof(IgnoreInputInInterceptionAttribute));
-                loggingService.Trace($"Async Func '{invocation.Method.Name}' called from '{invocation.TargetType.FullName}' with parameters '{(shouldIgnoreInput ? "ignored" : JsonConvert.SerializeObject(invocation.Arguments))}'.");
-                invocation.Proceed();
+                InterceptAsyncFunc(invocation);
             }
             else if (returnType == typeof(Task))
             {
@@ -45,7 +57,7 @@ namespace DFC.Digital.Core.Interceptors
         {
             bool shouldIgnoreInput = invocation.Method.CustomAttributes.Any(a => a.AttributeType == typeof(IgnoreInputInInterceptionAttribute));
             bool shouldIgnoreOutput = invocation.Method.CustomAttributes.Any(a => a.AttributeType == typeof(IgnoreOutputInInterceptionAttribute));
-            loggingService.Trace($"Method '{invocation.Method.Name}' called from '{invocation.TargetType.FullName}' with parameters '{(shouldIgnoreInput ? "ignored" : JsonConvert.SerializeObject(invocation.Arguments))}'.");
+            loggingService.Trace($"BEGIN: Method '{invocation.Method.Name}' called from '{invocation.TargetType.FullName}' with parameters '{(shouldIgnoreInput ? "ignored" : JsonConvert.SerializeObject(invocation.Arguments))}'.");
             Stopwatch watch = Stopwatch.StartNew();
             try
             {
@@ -53,7 +65,7 @@ namespace DFC.Digital.Core.Interceptors
             }
             finally
             {
-                loggingService.Trace($"Method '{invocation.Method.Name}' from '{invocation.TargetType.FullName}' took '{watch.Elapsed}' to complete. And returned '{(shouldIgnoreOutput ? "ignored" : invocation.ReturnValueString())}'");
+                loggingService.Trace($"END: Method '{invocation.Method.Name}' from '{invocation.TargetType.FullName}' took '{watch.Elapsed}' to complete. And returned '{(shouldIgnoreOutput ? "ignored" : invocation.ReturnValueString())}'");
             }
         }
 
@@ -61,20 +73,48 @@ namespace DFC.Digital.Core.Interceptors
         {
             bool shouldIgnoreInput = invocation.Method.CustomAttributes.Any(a => a.AttributeType == typeof(IgnoreInputInInterceptionAttribute));
             bool shouldIgnoreOutput = invocation.Method.CustomAttributes.Any(a => a.AttributeType == typeof(IgnoreOutputInInterceptionAttribute));
-            loggingService.Trace($"Async action '{invocation.Method.Name}' called from '{invocation.TargetType.FullName}' with parameters '{(shouldIgnoreInput ? "ignored" : JsonConvert.SerializeObject(invocation.Arguments))}'.");
+            loggingService.Trace($"BEGIN: Async action '{invocation.Method.Name}' called from '{invocation.TargetType.FullName}' with parameters '{(shouldIgnoreInput ? "ignored" : JsonConvert.SerializeObject(invocation.Arguments))}'.");
             Stopwatch watch = Stopwatch.StartNew();
             try
             {
                 invocation.Proceed();
                 if (invocation.ReturnValue is Task task)
                 {
-                    await task;
+                    await task.ConfigureAwait(false);
                 }
             }
             finally
             {
-                loggingService.Trace($"Async action '{invocation.Method.Name}' from '{invocation.TargetType.FullName}' took '{watch.Elapsed}' to complete.");
+                loggingService.Trace($"END: Async action '{invocation.Method.Name}' from '{invocation.TargetType.FullName}' took '{watch.Elapsed}' to complete.");
             }
+        }
+
+        private void InterceptAsyncFunc(IInvocation invocation)
+        {
+            bool shouldIgnoreInput = invocation.Method.CustomAttributes.Any(a => a.AttributeType == typeof(IgnoreInputInInterceptionAttribute));
+            loggingService.Trace($"BEGIN: Async Func '{invocation.Method.Name}' called from '{invocation.TargetType.FullName}' with parameters '{(shouldIgnoreInput ? "ignored" : JsonConvert.SerializeObject(invocation.Arguments))}'.");
+            invocation.Proceed();
+            var resultType = invocation.Method.ReturnType.GetGenericArguments()[0];
+            var mi = HandleAsyncMethodInfo.MakeGenericMethod(resultType);
+            invocation.ReturnValue = mi.Invoke(this, new[] { invocation });
+        }
+
+        private async Task<T> HandleAsyncWithResult<T>(IInvocation invocation)
+        {
+            bool shouldIgnoreOutput = invocation.Method.CustomAttributes.Any(a => a.AttributeType == typeof(IgnoreOutputInInterceptionAttribute));
+            T result = default;
+            Stopwatch watch = Stopwatch.StartNew();
+            try
+            {
+                result = await ((Task<T>)invocation.ReturnValue).ConfigureAwait(false);
+            }
+            finally
+            {
+                // other exception policies as we go along.
+                loggingService.Trace($"END: Async Func '{invocation.Method.Name}' from '{invocation.TargetType.FullName}' took '{watch.Elapsed}' to complete. And returned '{(shouldIgnoreOutput ? "ignored" : JsonConvert.SerializeObject(result))}'");
+            }
+
+            return result;
         }
     }
 }

--- a/DFC.Digital/DFC.Digital.Core/Interfaces/IApplicationLogger.cs
+++ b/DFC.Digital/DFC.Digital.Core/Interfaces/IApplicationLogger.cs
@@ -17,5 +17,7 @@ namespace DFC.Digital.Core
         void ErrorJustLogIt(string message, Exception ex);
 
         string LogExceptionWithActivityId(string message, Exception ex);
+
+        bool IsTraceDisabled();
     }
 }

--- a/DFC.Digital/DFC.Digital.Core/Logging/DFCLogger.cs
+++ b/DFC.Digital/DFC.Digital.Core/Logging/DFCLogger.cs
@@ -45,6 +45,11 @@ namespace DFC.Digital.Core.Logging
             return activityId;
         }
 
+        public bool IsTraceDisabled()
+        {
+            return !logService.IsTraceEnabled;
+        }
+
         public void Trace(string message)
         {
             logService.Trace(message);

--- a/DFC.Digital/DFC.Digital.Service.Cognitive.BingSpellCheck/Config/SpellCheckAutofacModule.cs
+++ b/DFC.Digital/DFC.Digital.Service.Cognitive.BingSpellCheck/Config/SpellCheckAutofacModule.cs
@@ -18,7 +18,12 @@ namespace DFC.Digital.Service.Cognitive.BingSpellCheck.Config
                 .InterceptedBy(InstrumentationInterceptor.Name, ExceptionInterceptor.Name)
                 ;
 
-            builder.RegisterType<HttpClientService<ISpellcheckService>>().AsImplementedInterfaces().SingleInstance();
+            builder.RegisterType<HttpClientService<ISpellcheckService>>()
+                .AsImplementedInterfaces()
+                .SingleInstance()
+                .EnableInterfaceInterceptors()
+                .InterceptedBy(InstrumentationInterceptor.Name, ExceptionInterceptor.Name)
+                ;
         }
     }
 }

--- a/DFC.Digital/DFC.Digital.Service.Cognitive.BingSpellCheck/SpellCheckService.cs
+++ b/DFC.Digital/DFC.Digital.Service.Cognitive.BingSpellCheck/SpellCheckService.cs
@@ -95,18 +95,23 @@ namespace DFC.Digital.Service.Cognitive.BingSpellCheck
                         }
                     }
                 }
+
+                return new SpellcheckResult
+                {
+                    OriginalTerm = term,
+                    CorrectedTerm = correctedTerm,
+                    HasCorrected = hasCorrections
+                };
             }
             catch (LoggedException)
             {
-                //applicationLogger.ErrorJustLogIt($"Failed to GetSpellCheckResponseAsync : {ex.Message}", ex);
+                //Ignore already logged exception and return default.
+                return new SpellcheckResult
+                {
+                    OriginalTerm = term,
+                    HasCorrected = false
+                };
             }
-
-            return new SpellcheckResult
-            {
-                OriginalTerm = term,
-                CorrectedTerm = correctedTerm,
-                HasCorrected = hasCorrections
-            };
         }
 
         private async Task<System.Net.Http.HttpResponseMessage> GetSpellCheckResponseAsync(string term)

--- a/DFC.Digital/DFC.Digital.Service.Cognitive.BingSpellCheck/SpellCheckService.cs
+++ b/DFC.Digital/DFC.Digital.Service.Cognitive.BingSpellCheck/SpellCheckService.cs
@@ -96,9 +96,9 @@ namespace DFC.Digital.Service.Cognitive.BingSpellCheck
                     }
                 }
             }
-            catch (HttpRequestException ex)
+            catch (LoggedException)
             {
-                applicationLogger.ErrorJustLogIt($"Failed to GetSpellCheckResponseAsync : {ex.Message}", ex);
+                //applicationLogger.ErrorJustLogIt($"Failed to GetSpellCheckResponseAsync : {ex.Message}", ex);
             }
 
             return new SpellcheckResult

--- a/DFC.Digital/DFC.Digital.Service.LMIFeed/Config/LmiFeedAutofacModule.cs
+++ b/DFC.Digital/DFC.Digital.Service.LMIFeed/Config/LmiFeedAutofacModule.cs
@@ -17,7 +17,12 @@ namespace DFC.Digital.Service.LMIFeed
                 .InterceptedBy(InstrumentationInterceptor.Name, ExceptionInterceptor.Name)
                 ;
 
-            builder.RegisterType<HttpClientService<IAsheHttpClientProxy>>().AsImplementedInterfaces().SingleInstance();
+            builder.RegisterType<HttpClientService<IAsheHttpClientProxy>>()
+                .AsImplementedInterfaces()
+                .SingleInstance()
+                .EnableInterfaceInterceptors()
+                .InterceptedBy(InstrumentationInterceptor.Name, ExceptionInterceptor.Name)
+                ;
         }
     }
 }


### PR DESCRIPTION
- Added interface interception for HttpClient service
- Extended interception to handle `Task<T>`
- Swallow exception in SpellCheckService