### PR TITLE
DFC-6256 - Updated the auth attribute to throw un-auth exception

### DIFF
--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.WebApi/Models/ApiAuthorizeAttribute.cs
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.WebApi/Models/ApiAuthorizeAttribute.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Web.Http;
 using System.Web.Http.Controllers;
+using Telerik.Sitefinity.Utilities.MS.ServiceModel.Web;
 using Telerik.Sitefinity.Web.Services;
 
 namespace DFC.Digital.Web.Sitefinity.WebApi
@@ -11,7 +12,21 @@ namespace DFC.Digital.Web.Sitefinity.WebApi
         protected override void HandleUnauthorizedRequest(HttpActionContext actionContext)
         {
             base.HandleUnauthorizedRequest(actionContext);
-            ServiceUtility.RequestBackendUserAuthentication();
+            try
+            {
+                ServiceUtility.RequestBackendUserAuthentication();
+            }
+            catch (WebProtocolException ex)
+            {
+                if (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                {
+                    throw new UnauthorizedAccessException();
+                }
+                else
+                {
+                    throw;
+                }
+            }
         }
     }
 }

--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.WebApi/Mvc/Controllers/AVFeedRecycleBinController.cs
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.WebApi/Mvc/Controllers/AVFeedRecycleBinController.cs
@@ -1,9 +1,6 @@
 ﻿using DFC.Digital.Data.Interfaces;
 using System.Net;
 using System.Web.Http;
-using Telerik.Sitefinity.Frontend.Mvc.Infrastructure.Controllers.Attributes;
-using Telerik.Sitefinity.Utilities.MS.ServiceModel.Web;
-using Telerik.Sitefinity.Web.Services;
 
 namespace DFC.Digital.Web.Sitefinity.WebApi
 {

--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.WebApi/Mvc/Controllers/AVFeedRecycleBinController.cs
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.WebApi/Mvc/Controllers/AVFeedRecycleBinController.cs
@@ -1,6 +1,7 @@
 ﻿using DFC.Digital.Data.Interfaces;
 using System.Net;
 using System.Web.Http;
+using Telerik.Sitefinity.Frontend.Mvc.Infrastructure.Controllers.Attributes;
 using Telerik.Sitefinity.Utilities.MS.ServiceModel.Web;
 using Telerik.Sitefinity.Web.Services;
 


### PR DESCRIPTION
So that we know the exception type at the client side. There will be further changes in the client to deserialise the exception so that appropriate status code can be returned to the function application.