### PR TITLE
Bug/dfc 10866 issue with event states with different jobprofile ids for master version

### DIFF
--- a/DFC.Digital/DFC.Digital.Core/Utilities/Constants.cs
+++ b/DFC.Digital/DFC.Digital.Core/Utilities/Constants.cs
@@ -145,6 +145,8 @@ namespace DFC.Digital.Core
         public const string WYDIntroduction = "WYDIntroduction";
         public const string WYDDayToDayTasks = "WYDDayToDayTasks";
 
+        //Orginal Content Id is used where master version Id is needed
+        public const string OriginalContentId = "OriginalContentId";
         public const string MicroServiceEndPointConfigKey = "MicroServiceEndPointConfigKey";
         public const string MicroServiceHelpPreviewEndPoint = "DFC.Digital.MicroService.HelpPreviewEndPoint";
     }

--- a/DFC.Digital/DFC.Digital.Repository.SitefinityCMS/Modules/CompositeUI/DynamicContentConverter.cs
+++ b/DFC.Digital/DFC.Digital.Repository.SitefinityCMS/Modules/CompositeUI/DynamicContentConverter.cs
@@ -61,7 +61,7 @@ namespace DFC.Digital.Repository.SitefinityCMS.Modules
             DynamicModuleManager dynamicModuleManager = DynamicModuleManager.GetManager(Constants.DynamicProvider);
             var jobProfileMessage = new JobProfileMessage
             {
-                JobProfileId = dynamicContentExtensions.GetFieldValue<Guid>(content, "Id"),
+                JobProfileId = dynamicContentExtensions.GetFieldValue<Guid>(content, Constants.OriginalContentId),
                 Title = dynamicContentExtensions.GetFieldValue<Lstring>(content, nameof(JobProfileMessage.Title)),
                 WidgetContentTitle = dynamicContentExtensions.GetFieldValue<Lstring>(content, nameof(JobProfileMessage.WidgetContentTitle)),
                 AlternativeTitle = dynamicContentExtensions.GetFieldValue<Lstring>(content, nameof(JobProfileMessage.AlternativeTitle)),
@@ -135,7 +135,7 @@ namespace DFC.Digital.Repository.SitefinityCMS.Modules
                 {
                     relatedSkills.Add(new SocSkillMatrixItem
                     {
-                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, nameof(SocSkillMatrixItem.Id)),
+                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, Constants.OriginalContentId),
                         Title = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(SocSkillMatrixItem.Title)),
                         Contextualised = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(SocSkillMatrixItem.Contextualised)),
                         ONetAttributeType = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(SocSkillMatrixItem.ONetAttributeType)),
@@ -160,7 +160,7 @@ namespace DFC.Digital.Repository.SitefinityCMS.Modules
                 {
                     relatedSkillsData.Add(new FrameworkSkillItem
                     {
-                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, nameof(FrameworkSkillItem.Id)),
+                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, Constants.OriginalContentId),
                         Title = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(FrameworkSkillItem.Title)),
                         Description = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(FrameworkSkillItem.Description)),
                         ONetElementId = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(FrameworkSkillItem.ONetElementId))
@@ -196,7 +196,7 @@ namespace DFC.Digital.Repository.SitefinityCMS.Modules
                 {
                     restrictions.Add(new RestrictionItem
                     {
-                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, nameof(RestrictionItem.Id)),
+                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, Constants.OriginalContentId),
                         Title = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(RestrictionItem.Title)),
                         Info = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(RestrictionItem.Info))
                     });
@@ -213,7 +213,7 @@ namespace DFC.Digital.Repository.SitefinityCMS.Modules
 
             var socCodes = new SocCodeItem
             {
-                Id = content.Id,
+                Id = dynamicContentExtensions.GetFieldValue<Guid>(content, Constants.OriginalContentId),
                 SOCCode = dynamicContentExtensions.GetFieldValue<Lstring>(content, nameof(SocCode.SOCCode)),
                 Description = dynamicContentExtensions.GetFieldValue<Lstring>(content, nameof(SocCode.Description)),
                 UrlName = dynamicContentExtensions.GetFieldValue<Lstring>(content, nameof(SocCode.UrlName)),
@@ -229,7 +229,7 @@ namespace DFC.Digital.Repository.SitefinityCMS.Modules
         {
             var socCodes = new RelatedSocCodeItem
             {
-                Id = content.Id,
+                Id = dynamicContentExtensions.GetFieldValue<Guid>(content, Constants.OriginalContentId),
                 SOCCode = dynamicContentExtensions.GetFieldValue<Lstring>(content, nameof(SocCode.SOCCode)).ToLower()
             };
 
@@ -263,7 +263,7 @@ namespace DFC.Digital.Repository.SitefinityCMS.Modules
                 {
                     jobProfileRelatedCareerData.Add(new JobProfileRelatedCareerItem
                     {
-                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, nameof(JobProfileRelatedCareerItem.Id)),
+                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, Constants.OriginalContentId),
                         Title = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(JobProfileRelatedCareerItem.Title)),
                         ProfileLink = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, Constants.Url),
                     });
@@ -319,7 +319,7 @@ namespace DFC.Digital.Repository.SitefinityCMS.Modules
                 {
                     relatedContentTypes.Add(new WYDRelatedContentType
                     {
-                        Id = dynamicContentExtensions.GetFieldValue<Guid>(item, nameof(WYDRelatedContentType.Id)),
+                        Id = dynamicContentExtensions.GetFieldValue<Guid>(item, Constants.OriginalContentId),
                         Description = dynamicContentExtensions.GetFieldValue<Lstring>(item, nameof(WYDRelatedContentType.Description)),
                         Title = dynamicContentExtensions.GetFieldValue<Lstring>(item, nameof(WYDRelatedContentType.Title)),
                         Url = dynamicContentExtensions.GetFieldValue<Lstring>(item, Constants.Url),

--- a/DFC.Digital/DFC.Digital.Repository.SitefinityCMS/Modules/CompositeUI/HowToBecomeDataConverter.cs
+++ b/DFC.Digital/DFC.Digital.Repository.SitefinityCMS/Modules/CompositeUI/HowToBecomeDataConverter.cs
@@ -1,4 +1,5 @@
-﻿using DFC.Digital.Data.Model;
+﻿using DFC.Digital.Core;
+using DFC.Digital.Data.Model;
 using DFC.Digital.Repository.SitefinityCMS;
 using System;
 using System.Collections.Generic;
@@ -128,7 +129,7 @@ namespace DFC.Digital.Repository.SitefinityCMS.Modules
                     var link = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(MoreInformationLinkItem.Url));
                     linkItems.Add(new MoreInformationLinkItem
                     {
-                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, nameof(MoreInformationLinkItem.Id)),
+                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, Constants.OriginalContentId),
                         Title = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(MoreInformationLinkItem.Title)),
                         Url = !string.IsNullOrWhiteSpace(link) ? new Uri(link, UriKind.RelativeOrAbsolute) : default,
                         Text = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(MoreInformationLinkItem.Text)),
@@ -149,7 +150,7 @@ namespace DFC.Digital.Repository.SitefinityCMS.Modules
                 {
                     requirements.Add(new EntryRequirementItem
                     {
-                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, nameof(InfoDataItem.Id)),
+                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, Constants.OriginalContentId),
                         Title = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(InfoDataItem.Title)),
                         Info = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(InfoDataItem.Info))
                     });
@@ -169,7 +170,7 @@ namespace DFC.Digital.Repository.SitefinityCMS.Modules
                 {
                     requirements.Add(new RegistrationItem
                     {
-                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, nameof(InfoDataItem.Id)),
+                        Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, Constants.OriginalContentId),
                         Title = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(InfoDataItem.Title)),
                         Info = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(InfoDataItem.Info))
                     });

--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/DataEventHandling/DataEventProcessor.cs
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/DataEventHandling/DataEventProcessor.cs
@@ -77,12 +77,6 @@ namespace DFC.Digital.Web.Sitefinity.Core
 
             try
             {
-                //Get all the parentitem links when the status is Master and then get related data when the status is LIVE,
-                //This is an odd case that was there for the existing publishing, we need to find a betterway of doing this
-                //if (item.GetType().Name == Constants.SOCSkillsMatrix && item.ApprovalWorkflowState.Value == Constants.WorkflowStatusPublished && item.Status.ToString() == Constants.ItemStatusMaster)
-                //{
-                //    SkillsMatrixParentItems = GetParentItemsForSocSkillsMatrix(item);
-                //}
                 if (eventAction == MessageAction.Ignored)
                 {
                     return;

--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/DataEventHandling/DataEventProcessor.cs
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/DataEventHandling/DataEventProcessor.cs
@@ -78,10 +78,10 @@ namespace DFC.Digital.Web.Sitefinity.Core
             {
                 //Get all the parentitem links when the status is Master and then get related data when the status is LIVE,
                 //This is an odd case that was there for the existing publishing, we need to find a betterway of doing this
-                if (item.GetType().Name == Constants.SOCSkillsMatrix && item.ApprovalWorkflowState.Value == Constants.WorkflowStatusPublished && item.Status.ToString() == Constants.ItemStatusMaster)
-                {
-                    SkillsMatrixParentItems = GetParentItemsForSocSkillsMatrix(item);
-                }
+                //if (item.GetType().Name == Constants.SOCSkillsMatrix && item.ApprovalWorkflowState.Value == Constants.WorkflowStatusPublished && item.Status.ToString() == Constants.ItemStatusMaster)
+                //{
+                //    SkillsMatrixParentItems = GetParentItemsForSocSkillsMatrix(item);
+                //}
 
                 if (eventAction == MessageAction.Ignored)
                 {
@@ -141,7 +141,8 @@ namespace DFC.Digital.Web.Sitefinity.Core
                         {
                             SkillsMatrixParentItems = GetParentItemsForSocSkillsMatrix(item);
                         }
-
+                        //var skillMatrixMasterVersionItems = 
+                        SkillsMatrixParentItems = GetParentItemsForSocSkillsMatrix(item);
                         GenerateServiceBusMessageForSocSkillsMatrixType(item, eventAction);
 
                         break;
@@ -330,7 +331,7 @@ namespace DFC.Digital.Web.Sitefinity.Core
                 //Get JobProfile Item
                 var relatedJobprofile = dynamicModuleManager.GetDataItem(dynamicType, jobProfileId);
 
-                if (relatedJobprofile.Status.ToString() == Constants.ItemStatusLive)
+                if (relatedJobprofile.Status.ToString() == Constants.ItemStatusMaster)
                 {
                     classificationData.Add(new ClassificationItem
                     {

--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/DataEventHandling/DataEventProcessor.cs
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/DataEventHandling/DataEventProcessor.cs
@@ -63,6 +63,7 @@ namespace DFC.Digital.Web.Sitefinity.Core
                 throw new ArgumentNullException("eventInfo");
             }
 
+            DynamicModuleManager dynamicModuleManager = DynamicModuleManager.GetManager(Constants.DynamicProvider);
             var eventAction = dynamicContentAction.GetDynamicContentEventAction(item);
 
             /*
@@ -72,7 +73,7 @@ namespace DFC.Digital.Web.Sitefinity.Core
             }
             */
 
-            applicationLogger.Trace($"Got event - |{item.GetType().Name.PadRight(15, ' ')} |{item.ApprovalWorkflowState.Value.PadRight(15, ' ')} | {item.Status.ToString().PadRight(15, ' ')} | Derived action - {eventAction.ToString().PadRight(15, ' ')}");
+            applicationLogger.Trace($"Got event - |{item.GetType().Name.PadRight(15, ' ')} -- {item.Id.ToString().PadRight(15, ' ')} |{item.ApprovalWorkflowState.Value.PadRight(15, ' ')} | {item.Status.ToString().PadRight(15, ' ')} | Derived action - {eventAction.ToString().PadRight(15, ' ')}");
 
             try
             {
@@ -82,7 +83,6 @@ namespace DFC.Digital.Web.Sitefinity.Core
                 //{
                 //    SkillsMatrixParentItems = GetParentItemsForSocSkillsMatrix(item);
                 //}
-
                 if (eventAction == MessageAction.Ignored)
                 {
                     return;
@@ -137,13 +137,12 @@ namespace DFC.Digital.Web.Sitefinity.Core
 
                     case Constants.SOCSkillsMatrix:
 
-                        if (eventAction == MessageAction.Deleted)
-                        {
-                            SkillsMatrixParentItems = GetParentItemsForSocSkillsMatrix(item);
-                        }
-                        //var skillMatrixMasterVersionItems = 
-                        SkillsMatrixParentItems = GetParentItemsForSocSkillsMatrix(item);
-                        GenerateServiceBusMessageForSocSkillsMatrixType(item, eventAction);
+                        //For all the Dynamic content types we are using Jobprofile as Parent Type
+                        //and for only Skills we are using SocSkillsMatrix Type as the Parent Type
+                        var masterItem = dynamicModuleManager.Lifecycle.GetMaster(item);
+                        var masterVersionItem = dynamicModuleManager.GetDataItem(item.GetType(), masterItem.Id);
+                        SkillsMatrixParentItems = GetParentItemsForSocSkillsMatrix(masterVersionItem);
+                        GenerateServiceBusMessageForSocSkillsMatrixType(item, masterVersionItem, eventAction);
 
                         break;
 
@@ -407,23 +406,10 @@ namespace DFC.Digital.Web.Sitefinity.Core
 
         private List<Guid> GetParentItemsForSocSkillsMatrix(DynamicContent item)
         {
-            DynamicModuleManager dynamicModuleManager = DynamicModuleManager.GetManager(Constants.DynamicProvider);
             var contentLinksManager = ContentLinksManager.GetManager();
             return contentLinksManager.GetContentLinks()
                    .Where(c => c.ParentItemType == ParentType && c.ChildItemId == item.Id)
                    .Select(c => c.ParentItemId).ToList();
-        }
-
-        private void GenerateServiceBusMessageForSocSkillsMatrixType(DynamicContent item, MessageAction eventAction)
-        {
-            DynamicModuleManager dynamicModuleManager = DynamicModuleManager.GetManager(Constants.DynamicProvider);
-            var contentLinksManager = ContentLinksManager.GetManager();
-            var parentItemContentLinks = contentLinksManager.GetContentLinks()
-                   .Where(c => c.ParentItemType == ParentType && c.ChildItemId == item.Id)
-                   .Select(c => c.ParentItemId).ToList();
-
-            var relatedSocSkillsMatrixContentTypes = GetSocSkillMatrixRelatedItems(item, parentItemContentLinks, dynamicModuleManager, ParentType);
-            serviceBusMessageProcessor.SendOtherRelatedTypeMessages(relatedSocSkillsMatrixContentTypes, item.GetType().Name, eventAction.ToString());
         }
 
         private void GenerateServiceBusMessageForWYDTypes(DynamicContent item, MessageAction eventAction)
@@ -492,21 +478,6 @@ namespace DFC.Digital.Web.Sitefinity.Core
             return relatedSocContentItems;
         }
 
-        private FrameworkSkillItem GetRelatedSkillsData(DynamicContent content, string relatedField)
-        {
-            var relatedSkillsData = new FrameworkSkillItem();
-            content.ProviderName = string.Empty;
-            var relatedItem = dynamicContentExtensions.GetRelatedItems(content, relatedField).FirstOrDefault();
-
-            return new FrameworkSkillItem
-            {
-                Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, nameof(FrameworkSkillItem.Id)),
-                Title = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(FrameworkSkillItem.Title)),
-                Description = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(FrameworkSkillItem.Description)),
-                ONetElementId = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(FrameworkSkillItem.ONetElementId))
-            };
-        }
-
         private RelatedSocCodeItem GenerateSocData(DynamicContent content)
         {
             var socCodes = new RelatedSocCodeItem
@@ -533,21 +504,33 @@ namespace DFC.Digital.Web.Sitefinity.Core
             return relatedSocsData;
         }
 
-        private IEnumerable<SocSkillMatrixContentItem> GetSocSkillMatrixRelatedItems(DynamicContent childItem, List<Guid> parentItemLinks, DynamicModuleManager dynamicModuleManager, string parentName)
+        private void GenerateServiceBusMessageForSocSkillsMatrixType(DynamicContent liveItem, DynamicContent masterItem, MessageAction eventAction)
+        {
+            DynamicModuleManager dynamicModuleManager = DynamicModuleManager.GetManager(Constants.DynamicProvider);
+            var contentLinksManager = ContentLinksManager.GetManager();
+            var parentItemContentLinks = contentLinksManager.GetContentLinks()
+                   .Where(c => c.ParentItemType == ParentType && c.ChildItemId == masterItem.Id)
+                   .Select(c => c.ParentItemId).ToList();
+
+            var relatedSocSkillsMatrixContentTypes = GetSocSkillMatrixRelatedItems(liveItem, parentItemContentLinks, dynamicModuleManager, ParentType);
+            serviceBusMessageProcessor.SendOtherRelatedTypeMessages(relatedSocSkillsMatrixContentTypes, liveItem.GetType().Name, eventAction.ToString());
+        }
+
+        private IEnumerable<SocSkillMatrixContentItem> GetSocSkillMatrixRelatedItems(DynamicContent childLiveItem, List<Guid> parentItemLinks, DynamicModuleManager dynamicModuleManager, string parentName)
         {
             var relatedSocSkillMatrixContentItems = new List<SocSkillMatrixContentItem>();
             var parentType = TypeResolutionService.ResolveType(ParentType);
 
             var socSkillsMatrixContent = new SocSkillMatrixContentItem
             {
-                Id = childItem.Id,
-                Title = dynamicContentExtensions.GetFieldValue<Lstring>(childItem, nameof(SocSkillMatrixContentItem.Title)),
-                Contextualised = dynamicContentExtensions.GetFieldValue<Lstring>(childItem, nameof(SocSkillMatrixContentItem.Contextualised)),
-                ONetAttributeType = dynamicContentExtensions.GetFieldValue<Lstring>(childItem, nameof(SocSkillMatrixContentItem.ONetAttributeType)),
-                ONetRank = dynamicContentExtensions.GetFieldValue<decimal?>(childItem, nameof(SocSkillMatrixContentItem.ONetRank)),
-                Rank = dynamicContentExtensions.GetFieldValue<decimal?>(childItem, nameof(SocSkillMatrixContentItem.Rank)),
-                RelatedSkill = GetRelatedSkillsData(childItem, nameof(SocSkillMatrixContentItem.RelatedSkill)),
-                RelatedSOC = GetRelatedSocsData(childItem, nameof(SocSkillMatrixContentItem.RelatedSOC))
+                Id = dynamicContentExtensions.GetFieldValue<Guid>(childLiveItem, Constants.OriginalContentId),
+                Title = dynamicContentExtensions.GetFieldValue<Lstring>(childLiveItem, nameof(SocSkillMatrixContentItem.Title)),
+                Contextualised = dynamicContentExtensions.GetFieldValue<Lstring>(childLiveItem, nameof(SocSkillMatrixContentItem.Contextualised)),
+                ONetAttributeType = dynamicContentExtensions.GetFieldValue<Lstring>(childLiveItem, nameof(SocSkillMatrixContentItem.ONetAttributeType)),
+                ONetRank = dynamicContentExtensions.GetFieldValue<decimal?>(childLiveItem, nameof(SocSkillMatrixContentItem.ONetRank)),
+                Rank = dynamicContentExtensions.GetFieldValue<decimal?>(childLiveItem, nameof(SocSkillMatrixContentItem.Rank)),
+                RelatedSkill = GetRelatedSkillsData(childLiveItem, nameof(SocSkillMatrixContentItem.RelatedSkill)),
+                RelatedSOC = GetRelatedSocsData(childLiveItem, nameof(SocSkillMatrixContentItem.RelatedSOC))
             };
 
             if (SkillsMatrixParentItems != null)
@@ -557,7 +540,7 @@ namespace DFC.Digital.Web.Sitefinity.Core
                     var parentItem = dynamicModuleManager.GetDataItem(parentType, contentId);
                     relatedSocSkillMatrixContentItems.Add(new SocSkillMatrixContentItem
                     {
-                        Id = childItem.Id,
+                        Id = dynamicContentExtensions.GetFieldValue<Guid>(childLiveItem, Constants.OriginalContentId),
                         Title = socSkillsMatrixContent.Title,
                         Contextualised = socSkillsMatrixContent.Contextualised,
                         ONetAttributeType = socSkillsMatrixContent.ONetAttributeType,
@@ -572,6 +555,21 @@ namespace DFC.Digital.Web.Sitefinity.Core
             }
 
             return relatedSocSkillMatrixContentItems;
+        }
+
+        private FrameworkSkillItem GetRelatedSkillsData(DynamicContent content, string relatedField)
+        {
+            var relatedSkillsData = new FrameworkSkillItem();
+            content.ProviderName = string.Empty;
+            var relatedItem = dynamicContentExtensions.GetRelatedItems(content, relatedField).FirstOrDefault();
+
+            return new FrameworkSkillItem
+            {
+                Id = dynamicContentExtensions.GetFieldValue<Guid>(relatedItem, Constants.OriginalContentId),
+                Title = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(FrameworkSkillItem.Title)),
+                Description = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(FrameworkSkillItem.Description)),
+                ONetElementId = dynamicContentExtensions.GetFieldValue<Lstring>(relatedItem, nameof(FrameworkSkillItem.ONetElementId))
+            };
         }
 
         private IEnumerable<Classification> MapClassificationData(TrackedList<Guid> classifications)


### PR DESCRIPTION
Issue -- There was an issue with IDs mismatch where  On JobProfile PUBLISH event we are sending LIVE version ID of the PUBLISH event and when Related Data was Published we are sending MASTER version of the PUBLISH event.
This was resolved by sending MASTER version of the PUBLISH event all the time.
