### PR TITLE
Url data added to WYD related content types

### DIFF
--- a/DFC.Digital/DFC.Digital.Data/Model/CompositeUI/MessageModels/WYDContentItem.cs
+++ b/DFC.Digital/DFC.Digital.Data/Model/CompositeUI/MessageModels/WYDContentItem.cs
@@ -11,5 +11,7 @@ namespace DFC.Digital.Data.Model
         public string Description { get; set; }
 
         public bool IsNegative { get; set; }
+
+        public string Url { get; set; }
     }
 }

--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/DataEventHandling/DataEventProcessor.cs
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/DataEventHandling/DataEventProcessor.cs
@@ -595,7 +595,8 @@ namespace DFC.Digital.Web.Sitefinity.Core
                     Id = dynamicContentExtensions.GetFieldValue<Guid>(childItem, nameof(WYDContentItem.Id)),
                     Title = dynamicContentExtensions.GetFieldValue<Lstring>(childItem, nameof(WYDContentItem.Title)),
                     Description = dynamicContentExtensions.GetFieldValue<Lstring>(childItem, nameof(WYDContentItem.Description)),
-                    IsNegative = dynamicContentExtensions.GetFieldValue<bool>(childItem, nameof(WYDContentItem.IsNegative))
+                    IsNegative = dynamicContentExtensions.GetFieldValue<bool>(childItem, nameof(WYDContentItem.IsNegative)),
+                    Url = dynamicContentExtensions.GetFieldValue<Lstring>(childItem, Constants.Url)
                 });
             }
 


### PR DESCRIPTION
In the WYD related data (uniforms, environments and locations) we are missing the Url when individual related content type was published.
