### PR TITLE
Fixed so that when a delete happens for classsification, don't try an…

### DIFF
--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.Core.UnitTests/DataEventProcessor/DataEventProcessorTests.cs
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.Core.UnitTests/DataEventProcessor/DataEventProcessorTests.cs
@@ -135,7 +135,7 @@ namespace DFC.Digital.Web.Sitefinity.Core.UnitTests
 
             //Act
             var dataEventHandler = new DataEventProcessor(fakeApplicationLogger, fakeCompositePageBuilder, fakeCompositeUIService, fakeAsyncHelper, fakeDataEventActions, fakeDynamicContentConverter, fakeServiceBusMessageProcessor, fakeDynamicContentExtensions, fakeDynamicContentAction);
-            dataEventHandler.ExportCompositePage(fakeDataEvent);
+            dataEventHandler.ExportContentData(fakeDataEvent);
 
             //Asserts
             if (expectToProcess)

--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/DataEventHandling/DataEventProcessor.cs
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/DataEventHandling/DataEventProcessor.cs
@@ -148,16 +148,32 @@ namespace DFC.Digital.Web.Sitefinity.Core
             }
         }
 
-        public void ExportCompositePage(IDataEvent eventInfo)
+        public void ExportContentData(IDataEvent eventInfo)
         {
             if (eventInfo == null)
             {
                 throw new ArgumentNullException("eventInfo");
             }
 
-            if (eventInfo.ItemType != typeof(PageNode) && eventInfo.ItemType != typeof(FlatTaxon))
+            if (eventInfo.ItemType == typeof(PageNode))
             {
-                return;
+                ExportCompositePage(eventInfo);
+            }
+            else if (eventInfo.ItemType == typeof(FlatTaxon))
+            {
+                //Don't do this for deletes as the TaxonItem will not exist by now, linked JPs will fire updated events.
+                if (eventInfo.Action != Constants.ItemActionDeleted)
+                {
+                    GetClassificationRelatedItems(eventInfo);
+                }
+            }
+        }
+
+        public void ExportCompositePage(IDataEvent eventInfo)
+        {
+            if (eventInfo == null)
+            {
+                throw new ArgumentNullException("eventInfo");
             }
 
             try
@@ -167,11 +183,6 @@ namespace DFC.Digital.Web.Sitefinity.Core
                 var itemId = eventInfo.ItemId;
                 var providerName = eventInfo.ProviderName;
                 var contentType = eventInfo.ItemType;
-
-                if (eventInfo.ItemType.Name == "FlatTaxon")
-                {
-                    GetClassificationRelatedItems(eventInfo);
-                }
 
                 if (microServicesDataEventAction == MicroServicesDataEventAction.PublishedOrUpdated)
                 {

--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/Interfaces/IDataEventProcessor.cs
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/Interfaces/IDataEventProcessor.cs
@@ -9,6 +9,8 @@ namespace DFC.Digital.Web.Sitefinity.Core
     {
         void ExportCompositePage(IDataEvent eventInfo);
 
+        void ExportContentData(IDataEvent eventInfo);
+
         void PublishDynamicContent(DynamicContent eventInfo);
     }
 }

--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/Startup.cs
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.Core/Startup.cs
@@ -82,7 +82,7 @@ namespace DFC.Digital.Web.Sitefinity.Core
         {
             var autofacLifetimeScope = AutofacDependencyResolver.Current.RequestLifetimeScope;
             var dataEventHandler = autofacLifetimeScope.Resolve<DataEventProcessor>();
-            dataEventHandler.ExportCompositePage(eventInfo);
+            dataEventHandler.ExportContentData(eventInfo);
         }
 
         // Event Action for Job Profile Dynamic content PUBLISH event


### PR DESCRIPTION
Fixed so that when a delete happens for classifications, don't try and export as it was throwing exception because the item is already deleted.

Logic tidy up.