### PR TITLE
Bug/dfc 11356 incorrect start date on course search results

### DIFF
--- a/DFC.Digital/DFC.Digital.Service.CourseSearch/DFC.Digital.Service.CourseSearchProvider.csproj
+++ b/DFC.Digital/DFC.Digital.Service.CourseSearch/DFC.Digital.Service.CourseSearchProvider.csproj
@@ -53,7 +53,7 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="DFC.FindACourseClient, Version=2.1.3.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="DFC.FindACourseClient, Version=2.1.4.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DFC.FindACourseClient.2.1.4\lib\netstandard2.0\DFC.FindACourseClient.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
@@ -367,7 +367,6 @@
     <None Include="..\DFC.Digital.CodeAnalysis.ruleset">
       <Link>DFC.Digital.CodeAnalysis.ruleset</Link>
     </None>
-    <None Include="app.config" />
     <None Include="Connected Services\CourseSearchServiceApi\CourseSearchService.wsdl" />
     <None Include="Connected Services\CourseSearchServiceApi\CourseSearchService.xsd">
       <SubType>Designer</SubType>

--- a/DFC.Digital/DFC.Digital.Service.CourseSearch/DFC.Digital.Service.CourseSearchProvider.csproj
+++ b/DFC.Digital/DFC.Digital.Service.CourseSearch/DFC.Digital.Service.CourseSearchProvider.csproj
@@ -53,7 +53,7 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="DFC.FindACourseClient, Version=2.1.4.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="DFC.FindACourseClient, Version=2.1.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DFC.FindACourseClient.2.1.4\lib\netstandard2.0\DFC.FindACourseClient.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
@@ -367,6 +367,7 @@
     <None Include="..\DFC.Digital.CodeAnalysis.ruleset">
       <Link>DFC.Digital.CodeAnalysis.ruleset</Link>
     </None>
+    <None Include="app.config" />
     <None Include="Connected Services\CourseSearchServiceApi\CourseSearchService.wsdl" />
     <None Include="Connected Services\CourseSearchServiceApi\CourseSearchService.xsd">
       <SubType>Designer</SubType>

--- a/DFC.Digital/DFC.Digital.Service.CourseSearch/DFC.Digital.Service.CourseSearchProvider.csproj
+++ b/DFC.Digital/DFC.Digital.Service.CourseSearch/DFC.Digital.Service.CourseSearchProvider.csproj
@@ -53,8 +53,8 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="DFC.FindACourseClient, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DFC.FindACourseClient.2.1.1\lib\netstandard2.0\DFC.FindACourseClient.dll</HintPath>
+    <Reference Include="DFC.FindACourseClient, Version=2.1.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DFC.FindACourseClient.2.1.4\lib\netstandard2.0\DFC.FindACourseClient.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNetCore.Hosting.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Hosting.Abstractions.dll</HintPath>
@@ -367,6 +367,7 @@
     <None Include="..\DFC.Digital.CodeAnalysis.ruleset">
       <Link>DFC.Digital.CodeAnalysis.ruleset</Link>
     </None>
+    <None Include="app.config" />
     <None Include="Connected Services\CourseSearchServiceApi\CourseSearchService.wsdl" />
     <None Include="Connected Services\CourseSearchServiceApi\CourseSearchService.xsd">
       <SubType>Designer</SubType>

--- a/DFC.Digital/DFC.Digital.Service.CourseSearch/DFC.Digital.Service.CourseSearchProvider.csproj
+++ b/DFC.Digital/DFC.Digital.Service.CourseSearch/DFC.Digital.Service.CourseSearchProvider.csproj
@@ -367,7 +367,6 @@
     <None Include="..\DFC.Digital.CodeAnalysis.ruleset">
       <Link>DFC.Digital.CodeAnalysis.ruleset</Link>
     </None>
-    <None Include="app.config" />
     <None Include="Connected Services\CourseSearchServiceApi\CourseSearchService.wsdl" />
     <None Include="Connected Services\CourseSearchServiceApi\CourseSearchService.xsd">
       <SubType>Designer</SubType>

--- a/DFC.Digital/DFC.Digital.Service.CourseSearch/packages.config
+++ b/DFC.Digital/DFC.Digital.Service.CourseSearch/packages.config
@@ -5,7 +5,7 @@
   <package id="AutoMapper" version="8.0.0" targetFramework="net472" />
   <package id="AutoMapper.Extensions.Microsoft.DependencyInjection" version="6.0.0" targetFramework="net472" />
   <package id="Castle.Core" version="4.3.1" targetFramework="net472" />
-  <package id="DFC.FindACourseClient" version="2.1.1" targetFramework="net472" />
+  <package id="DFC.FindACourseClient" version="2.1.4" targetFramework="net472" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.2.0" targetFramework="net472" />
   <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="2.2.0" targetFramework="net472" />

--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.CourseModule.UnitTests/DFC.Digital.Web.Sitefinity.CourseModule.UnitTests.csproj
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.CourseModule.UnitTests/DFC.Digital.Web.Sitefinity.CourseModule.UnitTests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Services\BuildQueryStringServiceTests.cs" />
     <Compile Include="Services\CourseSearchViewModelServiceTests.cs" />
     <Compile Include="Views\CourseLandingViewTests.cs" />
+    <Compile Include="Views\CourseSearchResultLocationTests.cs" />
     <Compile Include="Views\CourseSearchResultsViewTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.CourseModule.UnitTests/Views/CourseSearchResultLocationTests.cs
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.CourseModule.UnitTests/Views/CourseSearchResultLocationTests.cs
@@ -1,0 +1,65 @@
+﻿using ASP;
+using DFC.Digital.Data.Model;
+using FluentAssertions;
+using HtmlAgilityPack;
+using RazorGenerator.Testing;
+using System.Linq;
+using Xunit;
+
+namespace DFC.Digital.Web.Sitefinity.CourseModule.UnitTests
+{
+    public class CourseSearchResultLocationTests
+    {
+        private readonly _MVC_Views_CourseSearchResults_CourseDetail_cshtml courseDetailsView;
+        private readonly CourseListingViewModel courseListingViewModel;
+
+        public CourseSearchResultLocationTests()
+        {
+            courseDetailsView = new _MVC_Views_CourseSearchResults_CourseDetail_cshtml();
+            courseListingViewModel = new CourseListingViewModel
+            {
+                LocationLabel = "LocationLabel",
+                ProviderLabel = "ProviderLabel",
+                AdvancedLoanProviderLabel = "AdvancedLoanProviderLabel",
+                StartDateLabel = "StartDateLabel",
+                Course = new Course()
+            };
+        }
+
+        [Fact]
+        public void CourseDetailsViewNullLocationDetails()
+        {
+            // Act
+            var htmlDom = courseDetailsView.RenderAsHtml(courseListingViewModel);
+
+            // Assert
+            htmlDom.DocumentNode.InnerText.Should().NotContain(courseListingViewModel.LocationLabel);
+        }
+
+        [Fact]
+        public void CourseDetailsViewNullLocationAddress()
+        {
+            //Arrange
+            courseListingViewModel.Course.LocationDetails = new LocationDetails();
+
+            // Act
+            var htmlDom = courseDetailsView.RenderAsHtml(courseListingViewModel);
+
+            // Assert
+            htmlDom.DocumentNode.InnerText.Should().NotContain(courseListingViewModel.LocationLabel);
+        }
+
+        [Fact]
+        public void CourseDetailsViewVaildLocationAddress()
+        {
+            //Arrange
+            courseListingViewModel.Course.LocationDetails = new LocationDetails() { LocationAddress = "LocationAddress" };
+
+            // Act
+            var htmlDom = courseDetailsView.RenderAsHtml(courseListingViewModel);
+
+            // Assert
+            htmlDom.DocumentNode.InnerText.Should().Contain(courseListingViewModel.Course.LocationDetails.LocationAddress);
+        }
+    }
+}

--- a/DFC.Digital/DFC.Digital.Web.Sitefinity.CourseModule/Mvc/Views/CourseSearchResults/CourseDetail.cshtml
+++ b/DFC.Digital/DFC.Digital.Web.Sitefinity.CourseModule/Mvc/Views/CourseSearchResults/CourseDetail.cshtml
@@ -9,9 +9,9 @@
         <li class="govuk-!-margin-top-3">
             <span class="govuk-secondary-colour">@Model.ProviderLabel</span> @Model.Course.ProviderName
         </li>
-        
+
         @* Add logic here so location appears on CLASSROOM BASED courses as full venue address. The subregion will be shown on WORK BASED courses. This field SHOULD NOT appear on ONLINE courses. *@
-        @if (Model.Course.LocationDetails != null)
+        @if (!String.IsNullOrEmpty(Model.Course.LocationDetails?.LocationAddress))
         {
             <li>
                 <span class="govuk-secondary-colour">@Model.LocationLabel</span> @Model.Course.LocationDetails.LocationAddress @(Model.Course.LocationDetails.Distance.Equals(default(float)) ? string.Empty : $"({Model.Course.LocationDetails.Distance} miles)" )
@@ -19,7 +19,7 @@
         }
 
         <li>
-            <span class="govuk-secondary-colour">@Model.StartDateLabel</span> To be implemented - if flexible then show "Flexible" otherwise date
+            <span class="govuk-secondary-colour">@Model.StartDateLabel</span> @Model.Course.StartDateLabel
         </li>
     </ul>
 </div>


### PR DESCRIPTION
Changed to use version 2.1.4 of the find a course package.
Location is now only displayed when when is its not null or empty